### PR TITLE
Move external showing ID from program to broadcast slot entity

### DIFF
--- a/rest/snippets/EnrichedMetadata/ProgramEntity.yml
+++ b/rest/snippets/EnrichedMetadata/ProgramEntity.yml
@@ -56,8 +56,6 @@
         type: array
         items:
           type: object
-          required:
-          - external_showing_id
           properties:
             provider:
               type: string
@@ -66,10 +64,6 @@
               type: string
               example: "5271885"
               description: This is the id of the program in the foreign metadata provider
-            external_showing_id:
-              type: string
-              example: "724693092"
-              description: This is used by recommendation engines (like xroadmedia)
       created_at:
         type: integer
         example: 1516804728

--- a/rest/snippets/EnrichedMetadata/ProgramEntity.yml
+++ b/rest/snippets/EnrichedMetadata/ProgramEntity.yml
@@ -57,8 +57,7 @@
         items:
           type: object
           required:
-          - provider
-          - external_program_id
+          - external_showing_id
           properties:
             provider:
               type: string

--- a/rest/snippets/Epg/BroadcastSlotEntity.yml
+++ b/rest/snippets/Epg/BroadcastSlotEntity.yml
@@ -51,6 +51,21 @@ BroadcastSlotEntity:
           type: integer
           example: 120
           description: "How much time is devoted to adverts.  The length of the program plus the commercial breaks should total the seconds betwen start_time and end_time"
+        metadata_provider_information:
+          type: array
+          items:
+            type: object
+            required:
+            - provider
+            - external_showing_id
+            properties:
+              provider:
+                type: string
+                example: "ERICSSON"
+              external_showing_id:
+                type: string
+                example: "724693092"
+                description: This is used by recommendation engines (like xroadmedia)
         broadcast_languages:
           type: array
           items:

--- a/rest/snippets/Epg/BroadcastSlotEntity.yml
+++ b/rest/snippets/Epg/BroadcastSlotEntity.yml
@@ -57,12 +57,12 @@ BroadcastSlotEntity:
             type: object
             required:
             - provider
-            - external_showing_id
+            - external_id
             properties:
               provider:
                 type: string
                 example: "ERICSSON"
-              external_showing_id:
+              external_id:
                 type: string
                 example: "724693092"
                 description: This is used by recommendation engines (like xroadmedia)

--- a/rest/snippets/Schedule/BroadcastSlotEntity.yml
+++ b/rest/snippets/Schedule/BroadcastSlotEntity.yml
@@ -42,12 +42,12 @@ BroadcastSlotEntity:
         type: object
         required:
         - provider
-        - external_showing_id
+        - external_id
         properties:
           provider:
             type: string
             example: "ERICSSON"
-          external_showing_id:
+          external_id:
             type: string
             example: "724693092"
             description: This is used by recommendation engines (like xroadmedia)

--- a/rest/snippets/Schedule/BroadcastSlotEntity.yml
+++ b/rest/snippets/Schedule/BroadcastSlotEntity.yml
@@ -36,6 +36,21 @@ BroadcastSlotEntity:
       type: integer
       example: 120
       description: "How much time is devoted to adverts.  The length of the program plus the commercial breaks should total the seconds betwen start_time and end_time"
+    metadata_provider_information:
+      type: array
+      items:
+        type: object
+        required:
+        - provider
+        - external_showing_id
+        properties:
+          provider:
+            type: string
+            example: "ERICSSON"
+          external_showing_id:
+            type: string
+            example: "724693092"
+            description: This is used by recommendation engines (like xroadmedia)
     broadcast_languages:
       type: array
       items:


### PR DESCRIPTION
https://jira.aminocom.com/browse/BPLAT-12964
- `provider` and `external_program_id` in `ProgramEntity` are not mandatory
- remove `external_showing_id` from `ProgramEntity`
- add optional `metadata_provider_information` to `BroadcastSlotEntity`

preview: https://confluence.aminocom.com/display/BPLAT/%5BWIP+-+Garrick%5D+API+draft+1#/BroadcastSlots/GetBroadcastSlotsIndex