### PR TITLE
Change license order_id and payment attributes to nullable

### DIFF
--- a/rest/snippets/Config/LicenseEntity.yml
+++ b/rest/snippets/Config/LicenseEntity.yml
@@ -14,6 +14,7 @@ LicenseEntity:
       properties:
         order_id:
           type: string
+          nullable: true
           example: "1adc0dbe-3c65-4248-896c-78c049e276c8"
         status:
           type: string
@@ -34,18 +35,22 @@ LicenseEntity:
           properties:
             price_currency_amount:
               type: number
+              nullable: true
               example: 12.23
               description: The float (double precision) amount of currency that was paid (some fiat currencies have three decimal points of precision)
             price_currency_iso4217:
               type: string
               example: EUR
+              nullable: true
               description: The ISO-4217 code of the currency (https://en.wikipedia.org/wiki/ISO_4217)
             purchase_timestamp:
               type: integer
+              nullable: true
               example: 1526648593
               description: The Unix timestamp at which this license was purchased
             payment_method:
               type: string
+              nullable: true
               example: credit card
               description: The purchase instrument
     relationships:

--- a/rest/snippets/Config/LicenseEntity.yml
+++ b/rest/snippets/Config/LicenseEntity.yml
@@ -33,7 +33,7 @@ LicenseEntity:
           type: object
           properties:
             price_currency_amount:
-              type: float
+              type: number
               example: 12.23
               description: The float (double precision) amount of currency that was paid (some fiat currencies have three decimal points of precision)
             price_currency_iso4217:

--- a/rest/snippets/Config/ProductEntity.yml
+++ b/rest/snippets/Config/ProductEntity.yml
@@ -33,7 +33,7 @@ ProductEntity:
           example: true
           description: If this is false then the product is free of charge
         price_currency_amount:
-          type: float
+          type: number
           example: 12.23
           description: The float (double precision) amount of currency that was paid (some fiat currencies have three decimal points of precision)
         price_currency_iso4217:


### PR DESCRIPTION
https://jira.aminocom.com/browse/BPLAT-13049
- Change license order_id and payment attributes to nullable
- Fix for invalid type: float
![gnome-shell-screenshot-9NBQI0](https://user-images.githubusercontent.com/29536745/77875948-3776bf00-7284-11ea-8af6-ab0993d5ead0.png)

