### PR TITLE
Add starts_before parameter to get recording groups endpoint

### DIFF
--- a/rest/endpoints/user_recordings/profile_recordings.yml
+++ b/rest/endpoints/user_recordings/profile_recordings.yml
@@ -466,7 +466,7 @@ paths:
                     type: array
                     items:
                       $ref: "../../snippets/Epg/BroadcastSlotEntity.yml#/BroadcastSlotEntity"
-                      
+
   # ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
   # AUTOMATED RECORDING REQUESTS
   # ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -602,7 +602,7 @@ paths:
         204:
           description: |
             The resource was updated successfully, no response body is needed
-            
+
     delete:
       description: |
         * **Available since:** 2020-02 (BPLAT-12074)
@@ -665,10 +665,19 @@ paths:
           schema:
             type: string
         - in: query
-          name: filter
-          description: >-
-            Please see http://jsonapi.org/recommendations/#filtering. The following are attributes to filter on: [is_favourite]
-            Accepted values for the "is_favourite" filter: "true", "false", "1", "0"
+          name: filter[is_favourite]
+          description: Return only recordings with specificed favourite flag.
+          schema:
+            type: string
+            enum:
+              - true
+              - false
+              - 1
+              - 0
+        - in: query
+          name: filter[starts_before]
+          description: Return only recordings which were broadcasted before specified time, in Unix epoch timestamp.
+          example: 1526648593
           schema:
             type: string
 

--- a/rest/endpoints/user_recordings/profile_recordings.yml
+++ b/rest/endpoints/user_recordings/profile_recordings.yml
@@ -676,7 +676,7 @@ paths:
               - 0
         - in: query
           name: filter[starts_before]
-          description: Return only recordings which were broadcasted before specified time, in Unix epoch timestamp.
+          description: Return only recordings with broadcast start time before specified time, in Unix timestamp.
           example: 1526648593
           schema:
             type: string
@@ -822,4 +822,3 @@ paths:
                     type: array
                     items:
                       $ref: "../../snippets/Epg/BroadcastSlotEntity.yml#/BroadcastSlotEntity"
-


### PR DESCRIPTION
https://jira.24i.com/browse/BPLAT-14674

[preview](https://confluence.aminocom.com/display/BPLAT/%5BWIP+-+Garrick%5D+API+draft#/Recording%20Groups/indexRecordingGroups)